### PR TITLE
Add Yandex CDN for Russian users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Note that valid CDN symbols are:
 :google_schemeless
 :microsoft
 :jquery
+:yandex
 ```
 
 It will generate the following on production:

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -10,7 +10,8 @@ module Jquery::Rails::Cdn
       :google_ssl         => "https://ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
       :google_schemeless  => "//ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
       :microsoft          => "http://ajax.aspnetcdn.com/ajax/jQuery/jquery-#{JQUERY_VERSION}.min.js",
-      :jquery             => "http://code.jquery.com/jquery-#{JQUERY_VERSION}.min.js"
+      :jquery             => "http://code.jquery.com/jquery-#{JQUERY_VERSION}.min.js",
+      :yandex             => "http://yandex.st/jquery/#{JQUERY_VERSION}/jquery.js"
     }
 
     def jquery_url(name, options = {})


### PR DESCRIPTION
[Yandex](http://en.wikipedia.org/wiki/Yandex) is most popular search engine (more than Google) in Russian and exUSSR countries. They have [own CDN](http://api.yandex.ru/jslibs/libs.xml) located in Russia, so it is faster than Google.
