### PR TITLE
Remove unnecessary Google CDN URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Note that valid CDN symbols are:
 
 ```ruby
 :google
-:google_ssl
-:google_schemeless
 :microsoft
 :jquery
 ```

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -6,9 +6,7 @@ module Jquery::Rails::Cdn
     JQUERY_VERSION = Jquery::Rails::JQUERY_VERSION
     OFFLINE = (Rails.env.development? or Rails.env.test?)
     URL = {
-      :google             => "http://ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
-      :google_ssl         => "https://ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
-      :google_schemeless  => "//ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
+      :google             => "//ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
       :microsoft          => "http://ajax.aspnetcdn.com/ajax/jQuery/jquery-#{JQUERY_VERSION}.min.js",
       :jquery             => "http://code.jquery.com/jquery-#{JQUERY_VERSION}.min.js"
     }


### PR DESCRIPTION
Library now has 3 google URLs: HTTP `google`, HTTPS `google_ssl` and `google_schemeless`. Why we need so many if schemeless work perfect for HTTP and HTTPS (and developer doesn’t to think about protocols). Google recommend schemeless URL on [CDN page](https://developers.google.com/speed/libraries/devguide#jquery). Stackoverflow also [says](http://stackoverflow.com/questions/4831741/can-i-change-all-my-http-links-to-just), that schemeless is safe.
