### PR TITLE
Set Google CDN by default in helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,13 @@ If you're using asset pipeline with Rails 3.1+, first remove `//= require jquery
 Then in layout:
 
 ```ruby
-= jquery_include_tag :google
+= jquery_include_tag
 = javascript_include_tag 'application'
+```
+
+By default it use Google CDN, but you can change it:
+```ruby
+= jquery_include_tag :jquery
 ```
 
 Note that valid CDN symbols are:

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -13,7 +13,7 @@ module Jquery::Rails::Cdn
       :jquery             => "http://code.jquery.com/jquery-#{JQUERY_VERSION}.min.js"
     }
 
-    def jquery_url(name, options = {})
+    def jquery_url(name = :google, options = {})
       URL[name]
     end
 


### PR DESCRIPTION
Anyway most of users will use Google CDN (most popular CDN is better, because more users will have jQuery in browser cache), so maybe `:google` must be default CDN? It’s Rails like “convention over configuration” (less code for default case).
