### PR TITLE
Use protocol-independent urls for Yandex and Microsoft CDNs

### DIFF
--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -7,9 +7,9 @@ module Jquery::Rails::Cdn
     OFFLINE = (Rails.env.development? or Rails.env.test?)
     URL = {
       :google             => "//ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
-      :microsoft          => "http://ajax.aspnetcdn.com/ajax/jQuery/jquery-#{JQUERY_VERSION}.min.js",
+      :microsoft          => "//ajax.aspnetcdn.com/ajax/jQuery/jquery-#{JQUERY_VERSION}.min.js",
       :jquery             => "http://code.jquery.com/jquery-#{JQUERY_VERSION}.min.js",
-      :yandex             => "http://yandex.st/jquery/#{JQUERY_VERSION}/jquery.min.js"
+      :yandex             => "//yandex.st/jquery/#{JQUERY_VERSION}/jquery.min.js"
     }
 
     def jquery_url(name, options = {})


### PR DESCRIPTION
Serve jQuery through Yandex and Microsoft via protocol-independent urls.
