### PR TITLE
Add ability to use jQuery2 from `jquery-rails`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ On top of that, if you're using asset pipeline, you may have noticed that the ma
 
 Changelog:
 
+* v1.0.4: jQuery2 used by default now. Added option `use_v1` option which allows you to use jQuery instead of jQuery2. If `jquery-rails` gem is old and has no jQuery2 then jQuery will be used.
 * v1.0.0: Options like `defer: true` or `data-turbolinks-eval: false` are allowed to be passed. (Thanks to @mkitt)
 * v0.4.0: Added Cloudflare. (Thanks to @damonmorgan)
 * v0.3.0: Microsoft and Yandex are now always scheme-less. (Thanks to @atipugin)
@@ -53,8 +54,9 @@ If you're using asset pipeline with Rails 3.1+,
 - Put the following line in `config/application.rb`, so that jquery.js will be served from your server when CDN is not available.
 
 ```ruby
-config.assets.precompile += ['jquery.js']
+config.assets.precompile += ['jquery2.js']
 ```
+or `config.assets.precompile += ['jquery.js']` if you want to use jQuery v1.
 
 Then in layout:
 

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -14,7 +14,7 @@ module Jquery::Rails::Cdn
 
     def jquery_url(name, use_v1 = false)
       version = jquery_version(use_v1)
-      url(version)[name]
+      cdn_url(version)[name]
     end
 
     private
@@ -33,7 +33,7 @@ module Jquery::Rails::Cdn
       Jquery::Rails::JQUERY_VERSION
     end
 
-    def url(version)
+    def cdn_url(version)
       return unless version
       { google:     "//ajax.googleapis.com/ajax/libs/jquery/#{version}/jquery.min.js",
         microsoft:  "//ajax.aspnetcdn.com/ajax/jQuery/jquery-#{version}.min.js",

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -7,10 +7,16 @@ module Jquery::Rails::Cdn
 
     def jquery_include_tag(name, options = {})
       use_v1 = options.delete(:use_v1)
-      return javascript_include_tag(:jquery, options) if !options.delete(:force) and OFFLINE
 
-      [ javascript_include_tag(jquery_url(name, use_v1), options),
-        javascript_tag("window.jQuery || document.write(unescape('#{javascript_include_tag(:jquery, options).gsub('<','%3C')}'))")
+      return javascript_include_tag(:jquery, options) if !options.delete(:force) and OFFLINE
+      serve_cdn_version(name, options, use_v1)
+    end
+
+    def serve_cdn_version(name, options, use_v1)
+      jquery_asset = use_v1 ? :jquery : :jquery2
+
+      [javascript_include_tag(jquery_url(name, use_v1), options),
+       javascript_tag("window.jQuery || document.write(unescape('#{javascript_include_tag(jquery_asset, options).gsub('<', '%3C')}'))")
       ].join("\n").html_safe
     end
 

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -3,31 +3,39 @@ require 'jquery-rails-cdn/version'
 
 module Jquery::Rails::Cdn
   module ActionViewExtensions
-    JQUERY_VERSION = Jquery::Rails::JQUERY_VERSION
     OFFLINE = (Rails.env.development? or Rails.env.test?)
-    URL = {
-      :google             => "//ajax.googleapis.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js",
-      :microsoft          => "//ajax.aspnetcdn.com/ajax/jQuery/jquery-#{JQUERY_VERSION}.min.js",
-      :jquery             => "//code.jquery.com/jquery-#{JQUERY_VERSION}.min.js",
-      :yandex             => "//yandex.st/jquery/#{JQUERY_VERSION}/jquery.min.js",
-      :cloudflare         => "//cdnjs.cloudflare.com/ajax/libs/jquery/#{JQUERY_VERSION}/jquery.min.js"
-    }
-
-    def jquery_url(name)
-      URL[name]
-    end
 
     def jquery_include_tag(name, options = {})
+      use_v1 = options.delete(:use_v1)
       return javascript_include_tag(:jquery, options) if !options.delete(:force) and OFFLINE
 
-      [ javascript_include_tag(jquery_url(name), options),
+      [ javascript_include_tag(jquery_url(name, use_v1), options),
         javascript_tag("window.jQuery || document.write(unescape('#{javascript_include_tag(:jquery, options).gsub('<','%3C')}'))")
       ].join("\n").html_safe
+    end
+
+    def jquery_url(name, use_v1 = false)
+      version = jquery_version(use_v1)
+      url(version)[name]
+    end
+
+    def jquery_version(use_v1 = false)
+      use_v1 ? Jquery::Rails::JQUERY_VERSION : Jquery::Rails::JQUERY_2_VERSION
+    end
+    
+    def url(version)
+      return unless version
+      { google:     "//ajax.googleapis.com/ajax/libs/jquery/#{version}/jquery.min.js",
+        microsoft:  "//ajax.aspnetcdn.com/ajax/jQuery/jquery-#{version}.min.js",
+        jquery:     "//code.jquery.com/jquery-#{version}.min.js",
+        yandex:     "//yandex.st/jquery/#{version}/jquery.min.js",
+        cloudflare: "//cdnjs.cloudflare.com/ajax/libs/jquery/#{version}/jquery.min.js"
+      }
     end
   end
 
   class Railtie < Rails::Railtie
-    initializer 'jquery_rails_cdn.action_view' do |app|
+    initializer 'jquery_rails_cdn.action_view' do |_app|
       ActiveSupport.on_load(:action_view) do
         include Jquery::Rails::Cdn::ActionViewExtensions
       end

--- a/lib/jquery-rails-cdn.rb
+++ b/lib/jquery-rails-cdn.rb
@@ -12,6 +12,13 @@ module Jquery::Rails::Cdn
       serve_cdn_version(name, options, use_v1)
     end
 
+    def jquery_url(name, use_v1 = false)
+      version = jquery_version(use_v1)
+      url(version)[name]
+    end
+
+    private
+
     def serve_cdn_version(name, options, use_v1)
       jquery_asset = use_v1 ? :jquery : :jquery2
 
@@ -20,15 +27,12 @@ module Jquery::Rails::Cdn
       ].join("\n").html_safe
     end
 
-    def jquery_url(name, use_v1 = false)
-      version = jquery_version(use_v1)
-      url(version)[name]
-    end
-
     def jquery_version(use_v1 = false)
       use_v1 ? Jquery::Rails::JQUERY_VERSION : Jquery::Rails::JQUERY_2_VERSION
+    rescue NameError
+      Jquery::Rails::JQUERY_VERSION
     end
-    
+
     def url(version)
       return unless version
       { google:     "//ajax.googleapis.com/ajax/libs/jquery/#{version}/jquery.min.js",

--- a/lib/jquery-rails-cdn/version.rb
+++ b/lib/jquery-rails-cdn/version.rb
@@ -1,7 +1,7 @@
 module Jquery
   module Rails
     module Cdn
-      VERSION = '1.0.3'
+      VERSION = '1.0.4'
     end
   end
 end


### PR DESCRIPTION
This PR adds ability to use jQuery2 bundled with `jquery-rails` gem.
It also adds option to force jQuery v1 to be used. jQuery v1 will be used if `jquery-rails` gem does not have jQuery2.